### PR TITLE
Add ingredients needed to show details page

### DIFF
--- a/src/classes/Pantry.js
+++ b/src/classes/Pantry.js
@@ -1,24 +1,25 @@
-
 export default class Pantry {
-    constructor(pantryIngredients, recipeData) {
+    constructor(pantryIngredients) {
         this.ingredients = pantryIngredients
         this.missingIngredients = []
     }
     checkUserIngredients(recipe) {      
         recipe.requiredIngredients.forEach(ingredient => {
-            const found = this.ingredients.find(foundIngredient => foundIngredient.ingredient === ingredient.id)
+            const found = this.ingredients.find(foundIngredient => foundIngredient.id === ingredient.id)
             if (!found) {
                 this.missingIngredients.push({
                     name: ingredient.name,
                     id: ingredient.id,
-                    amount: ingredient.amount
+                    amount: ingredient.amount,
+                    unit: ingredient.unit
                 })
             } else {
                 if (found.amount < ingredient.amount) {
                     this.missingIngredients.push({
                         name: ingredient.name,
                         id: ingredient.id,
-                        amount: ingredient.amount - found.amount
+                        amount: ingredient.amount - found.amount,
+                        unit: ingredient.unit
                     })
                 }
             }
@@ -35,4 +36,3 @@ export default class Pantry {
         })
     }
 }
-

--- a/test/Pantry-test.js
+++ b/test/Pantry-test.js
@@ -5,7 +5,6 @@ import { usersData } from "../src/data/users"
 import { recipeData } from "../src/data/recipes"
 import Recipe from '../src/classes/Recipe';
 import Users from '../src/classes/Users'
-import Ingredient from '../src/classes/Ingredient'
 
 describe('Pantry Test', () => {
 
@@ -31,7 +30,6 @@ describe('Pantry Test', () => {
     it('Should be able to check a users pantry has enough of the ingredients', () => {
         recipe.makeIngredientData()
         pantry.checkUserIngredients(recipe)
-        console.log(pantry.missingIngredients)
         expect(pantry.missingIngredients.length).to.equal(4)
     })
 })


### PR DESCRIPTION
# Pull request
**Danielle**
**Add ingredients needed to show details page**
1. My user's story: As a user, I should not be able to cook a recipe if I don’t have the ingredients required.
2. Immediately showing the user what ingredients they still need to make the recipe they're viewing
3. Changed Let's Make It! button on search page to View Recipe
4. Added Let's Make It! button to View Recipe Details page
5. Functionality added to new Let's Make It! button: if the user has all the ingredients need it will display a message "Enjoy your meal!", else if the use does not have the ingredients needed it will take the user to their pantry so they can add the needed ingredients and the proper amount